### PR TITLE
Add compatibility for stable rustc pipeline

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -181,6 +181,13 @@ fn get_inner_type(items: Value, append_vec: bool) -> String {
     inner_type
 }
 
+/// Executes a closure if the Option contains a Some value.
+fn if_some<F: FnOnce(&T), T>(this: Option<T>, func: F) {
+    if let Some(ref x) = this {
+        func(x);
+    } 
+}
+
 /// Generates the Rust bindings from a file.
 pub fn gen(input_path: impl AsRef<std::path::Path>) {
     // Parse the schema.
@@ -265,27 +272,27 @@ pub fn gen(input_path: impl AsRef<std::path::Path>) {
 
     // For every path.
     for (name, path) in &yaml.paths {
-        path.get.as_ref().inspect(|op| {
+        if_some(path.get.as_ref(), |op| {
             paths_file
                 .write_all(pathop_to_string(name.clone(), op, "get").as_bytes())
                 .unwrap()
         });
-        path.put.as_ref().inspect(|op| {
+        if_some(path.put.as_ref(), |op| {
             paths_file
                 .write_all(pathop_to_string(name.clone(), op, "put").as_bytes())
                 .unwrap()
         });
-        path.post.as_ref().inspect(|op| {
+        if_some(path.post.as_ref(), |op| {
             paths_file
                 .write_all(pathop_to_string(name.clone(), op, "post").as_bytes())
                 .unwrap()
         });
-        path.patch.as_ref().inspect(|op| {
+        if_some(path.patch.as_ref(), |op| {
             paths_file
                 .write_all(pathop_to_string(name.clone(), op, "patch").as_bytes())
                 .unwrap()
         });
-        path.delete.as_ref().inspect(|op| {
+        if_some(path.delete.as_ref(), |op| {
             paths_file
                 .write_all(pathop_to_string(name.clone(), op, "delete").as_bytes())
                 .unwrap()

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -185,7 +185,7 @@ fn get_inner_type(items: Value, append_vec: bool) -> String {
 fn if_some<F: FnOnce(&T), T>(this: Option<T>, func: F) {
     if let Some(ref x) = this {
         func(x);
-    } 
+    }
 }
 
 /// Generates the Rust bindings from a file.


### PR DESCRIPTION
# What does this PR change?

Fix the issue with the `inspect` function being a nightly only feature.

<!-- provide a short description what exactly your PR changes here -->

Tick the applicable box:
- [ ] Add new feature
- [x] Bugifx
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [ ] General Maintenance

## Links

<!-- In case your changes fix an existing issue please link it below: -->

Fixes: N/A

- [x] DONE

## Documentation

<!-- provide description about documentation done here or remove this line -->

- No documentation needed
<br/>

- [x] DONE