### PR TITLE
Handle odd cases where schema is inaccurate

### DIFF
--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -154,18 +154,21 @@ pub fn type_to_string(ty: &ReferenceOr<Schema>) -> String {
                             }
                             None => "i64",
                         };
-                        return int_size.to_owned();
+                        int_size.to_owned()
                     }
                     // JSON object, but Rust has no easy way to support this, so just ask for a string.
-                    Type::Object(_) => "String".to_owned(),
+                    Type::Object(_) => "Option<std::collections::HashMap<String, serde_json::Value>>".to_owned(),
                     Type::Boolean(_) => "bool".to_owned(),
                     Type::Array(x) => {
                         let items = x.items.as_ref().unwrap().clone().unbox();
                         format!("Vec<{}>", type_to_string(&items))
                     }
                 },
+                SchemaKind::AllOf { all_of } => {
+                    format!("Option<{}>", type_to_string(&all_of[0].clone()))
+                },
                 // Very likely a JSON object.
-                _ => "String".to_owned(),
+                _ => "serde_json::Value".to_owned(),
             };
             // If property is nullable, we treat it as an optional argument.
             if item.schema_data.nullable {

--- a/src/bindgen.rs
+++ b/src/bindgen.rs
@@ -157,7 +157,9 @@ pub fn type_to_string(ty: &ReferenceOr<Schema>) -> String {
                         int_size.to_owned()
                     }
                     // JSON object, but Rust has no easy way to support this, so just ask for a string.
-                    Type::Object(_) => "Option<std::collections::HashMap<String, serde_json::Value>>".to_owned(),
+                    Type::Object(_) => {
+                        "Option<std::collections::HashMap<String, serde_json::Value>>".to_owned()
+                    }
                     Type::Boolean(_) => "bool".to_owned(),
                     Type::Array(x) => {
                         let items = x.items.as_ref().unwrap().clone().unbox();
@@ -166,7 +168,7 @@ pub fn type_to_string(ty: &ReferenceOr<Schema>) -> String {
                 },
                 SchemaKind::AllOf { all_of } => {
                     format!("Option<{}>", type_to_string(&all_of[0].clone()))
-                },
+                }
                 // Very likely a JSON object.
                 _ => "serde_json::Value".to_owned(),
             };


### PR DESCRIPTION
# What does this PR change?

Some OpenAPI schemas might be inaccurate and provide null values where they're not allowed. This PR takes a precaution by wrapping these fields in Option<T>.

Tick the applicable box:
- [ ] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [X] General Maintenance