### PR TITLE
Fix response handling for error codes

### DIFF
--- a/src/pathgen.rs
+++ b/src/pathgen.rs
@@ -132,7 +132,7 @@ fn gen_fn(name: &str, op_type: &str, op: &Operation) -> String {
     // Build the response enum.
     let fn_response_name = fn_name.to_case(Case::Pascal) + "Response";
     result +=
-        "#[derive(Serialize, Deserialize, Debug, Default, Clone)]\n#[serde(untagged)]\npub enum ";
+        "#[derive(Debug)]\npub enum ";
     result += &fn_response_name;
     result += " {\n";
 
@@ -152,8 +152,7 @@ fn gen_fn(name: &str, op_type: &str, op: &Operation) -> String {
         }
     }
 
-    result += "\t#[default]\n";
-    result += "\tNone\n";
+    result += "\tOther(Response)\n";
     result += "}\n";
 
     // Build function description.
@@ -238,9 +237,9 @@ fn gen_fn(name: &str, op_type: &str, op: &Operation) -> String {
     }
 
     // Unknown response code.
-    result += "\t\t_ => { Ok(";
+    result += "\t\tr#other_status => { Ok(";
     result += &fn_response_name;
-    result += "::None) }\n\t}\n}\n";
+    result += "::Other(r#response)) }\n\t}\n}\n";
 
     return result;
 }

--- a/src/templates/usings.template
+++ b/src/templates/usings.template
@@ -3,5 +3,5 @@
 use crate::util::ThanixClient;
 use crate::types::*;
 use serde_qs;
-use reqwest::Error;
+use reqwest::{Error, blocking::Response};
 


### PR DESCRIPTION
# What does this PR change?

All unknown response codes now store the `reqwest::Response` as a field in the `...Result` enums.

Tick the applicable box:
- [ ] Add new feature
- [ ] Security changes
- [ ] Tests
- [ ] Documentation changed
<br/>

- [X] General Maintenance